### PR TITLE
Fixes #103 feat(enhancement): Replaced timer, updated FAQ

### DIFF
--- a/src/components/FAQS.vue
+++ b/src/components/FAQS.vue
@@ -63,7 +63,15 @@ export default {
 					question: 'How do I submit my pull requests on Event Website? ',
 
 					answer:
-						'Head over to the Submit PR tab on your dashboard and fill the form accordingly.',
+						'It is quite simple! We guess you have figured it out already by now. If not, head onto the SubmitPR tab from the dashboard and select the repository from the drop-down list of repositories. A list of "merged" PRs will be displayed. Select your PR from the list to be submitted after ensuring that is has the proper tags assigned to it, if not ask the maintainer to do so and hit the Submit Button. Voila! Your PR is merged and corresponding points will be added in the dashboard.',
+
+					open: false,
+				},
+				{
+					question: 'Where can I see the PRs I have submitted?',
+
+					answer:
+						'Head onto the My PRs Tab in the dashboard to view your PRs that you have already submitted.',
 
 					open: false,
 				},
@@ -72,7 +80,7 @@ export default {
 					question: 'I am stuck. How do I get help?',
 
 					answer:
-						'Join our discord server (<a href="https://discord.gg/C72FYTYYcZ">click here to join</a>) and the mentors would be glad to help you there.',
+						'Join our discord server (<a href="https://discord.gg/C72FYTYYcZ">click here to join</a>) and the mentors would be glad to help you there or you can drop a message to the maintainers directly.',
 
 					open: false,
 				},

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -33,6 +33,26 @@
 			</div>
 		</div>
 
+		<!--COUNTDOWN-TIMER-SECTION-->
+		<div class="countdown-timer">
+			<p class="countdown-title">BSoC Ends in:</p>
+			<div class="timer" v-if="!hasEnded">
+				<span>
+					<span>{{ days }}</span> Days
+				</span>
+				<span>
+					<span>{{ hours }}</span> Hours
+				</span>
+				<span>
+					<span>{{ minutes }}</span> Minutes
+				</span>
+				<span>
+					<span>{{ seconds }}</span> Seconds
+				</span>
+			</div>
+			<p class="final-text" v-else>BSoC'24 has ended</p>
+		</div>
+
 		<!--  Prize Section-->
 
 		<div class="prize-section" id="prize">
@@ -65,26 +85,6 @@
 
 		<!--  FAQ Section-->
 		<FAQS></FAQS>
-
-		<!--COUNTDOWN-TIMER-SECTION-->
-		<div class="countdown-timer">
-			<p class="countdown-title">BSoC Ends in:</p>
-			<div class="timer" v-if="!hasEnded">
-				<span>
-					<span>{{ days }}</span> Days
-				</span>
-				<span>
-					<span>{{ hours }}</span> Hours
-				</span>
-				<span>
-					<span>{{ minutes }}</span> Minutes
-				</span>
-				<span>
-					<span>{{ seconds }}</span> Seconds
-				</span>
-			</div>
-			<p class="final-text" v-else>BSoC'24 has ended</p>
-		</div>
 	</div>
 </template>
 


### PR DESCRIPTION
## Overview


1. This PR fixes or fixes part of #103 .
2. This PR does the following: Replaced the timer to be placed at the desired location. Updated the FAQs portion of the webpage and made them in accordance with present.

## Essential Checklist

- [ x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [ x] The PR is made from a branch that's **not** called "main/master".

## Proof that changes are correct
<img width="1512" alt="Screenshot 2024-07-05 at 1 13 18 AM" src="https://github.com/bsoc-bitbyte/BSoC-Website/assets/136831315/c6110bf2-cbf0-496d-9030-14c0c69fcd1c">

The timer is placed below the Abouts section of the webpage.



<img width="1512" alt="Screenshot 2024-07-05 at 1 13 52 AM" src="https://github.com/bsoc-bitbyte/BSoC-Website/assets/136831315/c7b5fa1e-5072-43ab-a731-a8aceaf3764c">


Updated the FAQs of the webpage.


## PR Pointers

- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL".
- Never force push. If you do, your PR will be closed.
