### PR TITLE
fix: update countdown timer date and labels to bSoC 2026 end date

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -35,7 +35,7 @@
 			<a href="mailto:theprogclub@iiitdmj.ac.in" style="text-decoration: none"
 				>tpc.iiitdmj.ac.in</a
 			>
-			<div>(C) The Programming Club, IIITDMJ, 2024</div>
+			<div>(C) The Programming Club, IIITDMJ, 2026</div>
 		</div>
 	</div>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -82,7 +82,7 @@
 					<span class="timer-time">{{ seconds }}</span> Seconds
 				</span>
 			</div>
-			<p class="final-text" v-else>BSoC'24 has ended</p>
+			<p class="final-text" v-else>BSoC'26 has ended</p>
 		</div>
 
 		<!--  FAQ Section-->
@@ -218,7 +218,7 @@ export default {
 		const minutes = ref(0)
 		const seconds = ref(0)
 		const hasEnded = ref(false)
-		const countDownDate = new Date('July 31, 2024 00:00:00').getTime()
+		const countDownDate = new Date('July 31, 2026 00:00:00').getTime()
 
 		const updateCountdown = () => {
 			const now = new Date().getTime()


### PR DESCRIPTION
## 📌 What does this PR do?

- updates the countdown timer date according to BSoC 2026 end date. 
- updates the end message from BSoC'24 ended to BSoC'26 ended.
- updates outdated 2024 reference in footer to 2026.

---

## ✅ Summary of Changes

<!-- A quick checklist of what’s included -->
- [x] Feature added / Bug fixed
- [ ] Code refactored / cleaned up
- [x] UI updated (if applicable)
- [ ] Tests written or updated

---

## 📷 Screenshots / Demo (if applicable)

<img width="1373" height="382" alt="Screenshot 2026-06-11 190557" src="https://github.com/user-attachments/assets/7982f273-e1c5-407f-b024-11f02f9a92d2" />
<img width="1852" height="390" alt="Screenshot 2026-06-11 190611" src="https://github.com/user-attachments/assets/1b4ee2a9-7916-41b1-aa77-4cebba985ed8" />


---

## 💬 Notes for Reviewer

<!-- Anything the reviewer should keep in mind, questions you have, or context worth sharing -->
-

---

## Related Issues

<!-- Link any relevant issues or discussions -->
Closes #160 