### PR TITLE
fix: updated scoreboard logic for 2026

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -4,6 +4,14 @@ service cloud.firestore {
     match /{document=**} {
       allow read, write: if
           request.time < timestamp.date(2026,7,7);
+          }
+    match /dashboard-2026/{document} {
+      allow read, write: if request.auth!=null;
+          
+    }
+    match /userStats-2026/{document} {
+      allow read, write: if request.auth!=null;
+          
     }
   }
 }

--- a/src/composables/deleteDocuments.js
+++ b/src/composables/deleteDocuments.js
@@ -26,7 +26,7 @@ const deletePr = async (id, doc, difficulty, uid) => {
 			'Are you sure you want to delete ? \nThis action can not be undone.'
 		)
 	) {
-		const colRef = await projectFirestore.collection('dashboard-2025')
+		const colRef = await projectFirestore.collection('dashboard-2026')
 		const docRef = colRef.doc(doc.id)
 		docRef
 			.delete()
@@ -41,7 +41,7 @@ const deletePr = async (id, doc, difficulty, uid) => {
 		var new_prs = 0
 
 		await projectFirestore
-			.collection('userStats-2025')
+			.collection('userStats-2026')
 			.doc(uid)
 			.get()
 			.then((snapshot) => {
@@ -55,7 +55,7 @@ const deletePr = async (id, doc, difficulty, uid) => {
 			})
 
 		await projectFirestore
-			.collection('userStats-2025')
+			.collection('userStats-2026')
 			.doc(uid)
 			.update({ score: new_score, numberOfPRs: new_prs })
 

--- a/src/views/MyPR.vue
+++ b/src/views/MyPR.vue
@@ -72,7 +72,7 @@ import { projectAuth } from '../firebase/config'
 export default {
 	name: 'MyPR',
 	setup() {
-		const { documents } = getCollection('dashboard-2025')
+		const { documents } = getCollection('dashboard-2026')
 		const started = ref(true)
 		const userPR = ref(false)
 		var userData = new Map()

--- a/src/views/Scoreboard.vue
+++ b/src/views/Scoreboard.vue
@@ -5,6 +5,7 @@
 				<select v-model="selectedYear">
 					<option value="2024">BSoC 2024</option>
 					<option value="2025">BSoC 2025</option>
+					<option value="2026">BSoC 2026</option>
 				</select>
 				<input
 					type="text"
@@ -104,7 +105,7 @@ export default {
 		const numofitems = ref(10)
 		const pagenum = ref(1)
 		const searchQuery = ref('')
-		const selectedYear = ref('2025')
+		const selectedYear = ref('2026')
 
 		var userData = new Map()
 		var userPRData = new Map()

--- a/src/views/SubmitPR.vue
+++ b/src/views/SubmitPR.vue
@@ -182,7 +182,7 @@ export default {
 		const fetchSubmittedPRs = async () => {
 			try {
 				const submittedPRsSnapshot = await projectFirestore
-					.collection('dashboard-2025')
+					.collection('dashboard-2026')
 					.get()
 				submittedPRs.value = submittedPRsSnapshot.docs.map(
 					(doc) => doc.data().link
@@ -224,8 +224,8 @@ export default {
 				uid: projectAuth.currentUser.uid,
 			}
 
-			await updateUserStats('userStats-2025', doc, projectAuth.currentUser.uid)
-			await addDoc('dashboard-2025', doc)
+			await updateUserStats('userStats-2026', doc, projectAuth.currentUser.uid)
+			await addDoc('dashboard-2026', doc)
 			loading.value = false
 			successToast('Success', 'PR submitted successfully!')
 			await router.push('/scoreboard')

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -46,7 +46,7 @@ export default {
 	},
 
 	created() {
-		const documents = getSingleUserStats('dashboard-2025', this.userID)
+		const documents = getSingleUserStats('dashboard-2026', this.userID)
 		const difficulties = { 15: 'Easy', 30: 'Medium', 50: 'Hard' }
 
 		documents.then((val) => {


### PR DESCRIPTION
## 📌 What does this PR do?

- updates firestore collection references from 2025 to 2026 in `SubmitPR.vue` and `MyPR.vue`.
- adds 2026 in year dropdown list in `scoreboard.vue`. Also `selectedYear` default year to 2026.
- updates userStats-2025 and  dashboard-2025 references to 2026 in `User.vue` and `deleteDocuments.js`.
- adds rules in `firestore.rules` for userStats-2026 and  dashboard-2026.

---

## ✅ Summary of Changes

<!-- A quick checklist of what’s included -->
- [x] Feature added / Bug fixed
- [ ] Code refactored / cleaned up
- [ ] UI updated (if applicable)
- [ ] Tests written or updated

---

## 📷 Screenshots / Demo (if applicable)


<img width="1637" height="462" alt="Screenshot 2026-06-22 154857" src="https://github.com/user-attachments/assets/a6687689-3dc0-41bc-9844-58f5a889210f" />


---

## 💬 Notes for Reviewer

<!-- Anything the reviewer should keep in mind, questions you have, or context worth sharing -->
-

---

## Related Issues

<!-- Link any relevant issues or discussions -->
Closes #163 
